### PR TITLE
Additional ifdef + typo

### DIFF
--- a/src/core/communication.cpp
+++ b/src/core/communication.cpp
@@ -2305,6 +2305,7 @@ void mpi_galilei_transform_slave(int, int) {
 
 /****************** LEES_EDWARDS_IMAGE_RESET *******************/
 
+#ifdef LEES_EDWARDS
 void mpi_lees_edwards_image_reset() {
   mpi_call(mpi_lees_edwards_image_reset_slave, -1, 0);
   local_lees_edwards_image_reset();
@@ -2315,6 +2316,8 @@ void mpi_lees_edwards_image_reset_slave(int, int) {
   local_lees_edwards_image_reset();
   on_particle_change();
 }
+#endif
+
 /******************** REQ_SWIMMER_REACTIONS ********************/
 
 void mpi_setup_reaction() {

--- a/src/core/lees_edwards.cpp
+++ b/src/core/lees_edwards.cpp
@@ -87,7 +87,7 @@ double lees_edwards_get_velocity(double time) {
     return 0.0;
   }  
 }
-
+#ifdef LEES_EDWARDS
 void local_lees_edwards_image_reset() {
   for (auto &p : local_cells.particles()) {
     p.l.i[0] = 0;
@@ -96,3 +96,4 @@ void local_lees_edwards_image_reset() {
     p.p.lees_edwards_offset = 0;
     }
 }
+#endif

--- a/src/core/lees_edwards.hpp
+++ b/src/core/lees_edwards.hpp
@@ -4,7 +4,7 @@
 #include "config.hpp"
 #include "cells.hpp"
 
-/** \file lees_erdwards.hpp
+/** \file lees_edwards.hpp
 *
 */
 


### PR DESCRIPTION
We can now compile without LE switched on. 

However, the construction in lees_edwards.cpp is rather odd. 
I understand that the particle property is not defined without LE but we enforced with define that this file will be taken into account.

Maybe there is a nicer way? 